### PR TITLE
refactor: move Google Sheets fetch to service

### DIFF
--- a/lib/femenino_tables_screen.dart
+++ b/lib/femenino_tables_screen.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
-import 'package:csv/csv.dart';
 import 'dart:math' as math;
 //import 'package:google_fonts/google_fonts.dart';
 import 'custom_header.dart';
+import 'google_sheet_service.dart';
 
 class FemeninoTablesScreen extends StatefulWidget {
   const FemeninoTablesScreen({super.key});
@@ -41,16 +40,10 @@ class _FemeninoTablesScreenState extends State<FemeninoTablesScreen> {
       for (var entry in tablesGid.entries) {
         final tableName = entry.key;
         final gid = entry.value;
-        final url = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTH5wcJur5ysIqKDdpaRP3M1YDAXVME5Ztuo0zffL27P9crNqlDlbNp3Kg-DSOE9XapLGl9qwUO1hrZ/pub?gid=$gid&output=csv';
-
-        final response = await http.get(Uri.parse(url));
-
-        if (response.statusCode == 200) {
-          final csvData = const CsvToListConverter().convert(response.body);
-          setState(() {
-            _tablesData[tableName] = csvData;
-          });
-        }
+        final data = await GoogleSheetService.fetchSheet(gid);
+        setState(() {
+          _tablesData[tableName] = data;
+        });
       }
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/fixture_page.dart
+++ b/lib/fixture_page.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
-import 'package:csv/csv.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'custom_header.dart';
 import 'dart:math' as math;
+import 'google_sheet_service.dart';
 
 class FixturePage extends StatefulWidget {
   final String hoja;
@@ -27,16 +26,11 @@ class _FixturePageState extends State<FixturePage> {
   Future<void> _loadData() async {
     try {
       final gid = _getGidForHoja(widget.hoja);
-      final url = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTH5wcJur5ysIqKDdpaRP3M1YDAXVME5Ztuo0zffL27P9crNqlDlbNp3Kg-DSOE9XapLGl9qwUO1hrZ/pub?gid=$gid&output=csv';
-
-      final response = await http.get(Uri.parse(url));
-
-      if (response.statusCode == 200) {
-        setState(() {
-          _data = const CsvToListConverter().convert(response.body);
-          _loading = false;
-        });
-      }
+      final data = await GoogleSheetService.fetchSheet(gid);
+      setState(() {
+        _data = data;
+        _loading = false;
+      });
     } catch (e) {
       setState(() {
         _loading = false;

--- a/lib/google_sheet_service.dart
+++ b/lib/google_sheet_service.dart
@@ -1,0 +1,24 @@
+import 'package:csv/csv.dart';
+import 'package:http/http.dart' as http;
+
+class GoogleSheetService {
+  GoogleSheetService._();
+
+  static final Map<String, List<List<dynamic>>> _cache = {};
+
+  static Future<List<List<dynamic>>> fetchSheet(String gid) async {
+    if (_cache.containsKey(gid)) {
+      return _cache[gid]!;
+    }
+
+    final url = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTH5wcJur5ysIqKDdpaRP3M1YDAXVME5Ztuo0zffL27P9crNqlDlbNp3Kg-DSOE9XapLGl9qwUO1hrZ/pub?gid=' + gid + '&output=csv';
+    final response = await http.get(Uri.parse(url));
+
+    if (response.statusCode == 200) {
+      final data = const CsvToListConverter().convert(response.body);
+      _cache[gid] = data;
+      return data;
+    }
+    throw Exception('Failed to fetch sheet');
+  }
+}

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
-import 'package:csv/csv.dart';
 import 'custom_header.dart';
 import 'fixture_page.dart';
 import 'femenino_tables_screen.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'google_sheet_service.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -28,15 +27,11 @@ class _HomeScreenState extends State<HomeScreen> {
       _loading = true;
     });
 
-    const url = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTH5wcJur5ysIqKDdpaRP3M1YDAXVME5Ztuo0zffL27P9crNqlDlbNp3Kg-DSOE9XapLGl9qwUO1hrZ/pub?gid=970777381&output=csv';
-
     try {
-      final response = await http.get(Uri.parse(url));
-      if (response.statusCode == 200) {
-        setState(() {
-          _data = const CsvToListConverter().convert(response.body);
-        });
-      }
+      final data = await GoogleSheetService.fetchSheet('970777381');
+      setState(() {
+        _data = data;
+      });
     } catch (e) {
       // Manejo de errores
     }


### PR DESCRIPTION
## Summary
- add `GoogleSheetService` to centralize Google Sheets CSV fetching with simple caching
- refactor fixture, femenino tables, and home screens to use the new service instead of inline HTTP logic

## Testing
- `dart format lib/fixture_page.dart lib/femenino_tables_screen.dart lib/home_screen.dart lib/google_sheet_service.dart` *(fail: dart not installed)*
- `flutter test` *(fail: flutter not installed)*


------
https://chatgpt.com/codex/tasks/task_e_689f7ab683b88325af2b97148928e949