### PR TITLE
Add theme mode switch with persisted preferences

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -8,6 +8,7 @@ import 'about_page.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'google_sheet_service.dart';
+import 'theme_notifier.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -56,6 +57,23 @@ class _HomeScreenState extends State<HomeScreen> {
             const Padding(
               padding: EdgeInsets.fromLTRB(16, 30, 16, 8),
               child: HomeHeader(),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: ValueListenableBuilder<ThemeMode>(
+                valueListenable: themeNotifier,
+                builder: (context, mode, _) {
+                  return SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Modo oscuro'),
+                    value: mode == ThemeMode.dark,
+                    onChanged: (val) {
+                      themeNotifier.updateThemeMode(
+                          val ? ThemeMode.dark : ThemeMode.light);
+                    },
+                  );
+                },
+              ),
             ),
             _loading
                 ? const Center(child: CircularProgressIndicator())

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'splash_screen.dart';
+import 'theme_notifier.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await themeNotifier.loadThemeMode();
   runApp(const MyApp());
 }
 
@@ -11,16 +14,27 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'CSD Soler',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-        textTheme: GoogleFonts.robotoTextTheme(
-          Theme.of(context).textTheme,
-        ),
-      ),
-      home: const SplashScreen(),
-      debugShowCheckedModeBanner: false,
+    return ValueListenableBuilder<ThemeMode>(
+      valueListenable: themeNotifier,
+      builder: (context, mode, _) {
+        return MaterialApp(
+          title: 'CSD Soler',
+          theme: ThemeData(
+            primarySwatch: Colors.blue,
+            textTheme: GoogleFonts.robotoTextTheme(
+              ThemeData.light().textTheme,
+            ),
+          ),
+          darkTheme: ThemeData.dark().copyWith(
+            textTheme: GoogleFonts.robotoTextTheme(
+              ThemeData.dark().textTheme,
+            ),
+          ),
+          themeMode: mode,
+          home: const SplashScreen(),
+          debugShowCheckedModeBanner: false,
+        );
+      },
     );
   }
 }

--- a/lib/theme_notifier.dart
+++ b/lib/theme_notifier.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeNotifier extends ValueNotifier<ThemeMode> {
+  ThemeNotifier() : super(ThemeMode.system);
+
+  Future<void> loadThemeMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final modeName = prefs.getString('themeMode');
+    if (modeName != null) {
+      value = ThemeMode.values.firstWhere(
+        (m) => m.name == modeName,
+        orElse: () => ThemeMode.system,
+      );
+    }
+  }
+
+  Future<void> updateThemeMode(ThemeMode mode) async {
+    value = mode;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('themeMode', mode.name);
+  }
+}
+
+final ThemeNotifier themeNotifier = ThemeNotifier();


### PR DESCRIPTION
## Summary
- enable dynamic themeMode via ValueNotifier
- persist user-selected theme using shared_preferences
- add switch on home screen to toggle light and dark mode

## Testing
- `dart format lib/main.dart lib/home_screen.dart lib/theme_notifier.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1146e70dc8325a713c0ba28536fd4