### PR TITLE
Add Android home widget for upcoming matches

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,18 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <receiver
+            android:name="com.example.csdsolerapk.MatchHomeWidgetProvider"
+            android:exported="false"
+            android:label="Próximo Partido">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/match_widget_info" />
+        </receiver>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/kotlin/com/example/csdsolerapk/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/csdsolerapk/MainActivity.kt
@@ -1,5 +1,5 @@
 package com.example.csdsolerapk
 
-import io.flutter.embedding.android.FlutterActivity
+import es.antonborri.home_widget.HomeWidgetActivity
 
-class MainActivity : FlutterActivity()
+class MainActivity : HomeWidgetActivity()

--- a/android/app/src/main/kotlin/com/example/csdsolerapk/MatchHomeWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/example/csdsolerapk/MatchHomeWidgetProvider.kt
@@ -1,0 +1,71 @@
+package com.example.csdsolerapk
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.net.Uri
+import android.widget.RemoteViews
+import es.antonborri.home_widget.HomeWidgetProvider
+import es.antonborri.home_widget.HomeWidgetPlugin
+import es.antonborri.home_widget.HomeWidgetLaunchIntent
+import org.json.JSONArray
+
+class MatchHomeWidgetProvider : HomeWidgetProvider() {
+    companion object {
+        private const val ACTION_NEXT = "com.example.csdsolerapk.NEXT"
+        private const val ACTION_PREV = "com.example.csdsolerapk.PREV"
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+        widgetData: SharedPreferences?
+    ) {
+        val prefs = widgetData ?: HomeWidgetPlugin.getData(context)
+        val matchesJson = prefs.getString("matches", "[]")
+        val index = prefs.getInt("match_index", 0)
+        val matches = JSONArray(matchesJson)
+        val match = if (matches.length() > 0) matches.getJSONObject(index % matches.length()) else null
+
+        val views = RemoteViews(context.packageName, R.layout.match_widget)
+
+        if (match != null) {
+            views.setTextViewText(R.id.tvDay, match.optString("dia"))
+            views.setTextViewText(R.id.tvOpponent, match.optString("rival"))
+            views.setTextViewText(R.id.tvVenue, match.optString("localia"))
+
+            val lat = match.optString("lat")
+            val long = match.optString("long")
+            if (lat.isNotEmpty() && long.isNotEmpty()) {
+                val uri = Uri.parse("https://www.google.com/maps/search/?api=1&query=$lat,$long")
+                val mapIntent = HomeWidgetLaunchIntent.getActivity(context, MainActivity::class.java, uri)
+                views.setOnClickPendingIntent(R.id.btnMap, mapIntent)
+            }
+        }
+
+        val nextIntent = HomeWidgetLaunchIntent.getBroadcast(context, ACTION_NEXT)
+        views.setOnClickPendingIntent(R.id.btnNext, nextIntent)
+
+        val prevIntent = HomeWidgetLaunchIntent.getBroadcast(context, ACTION_PREV)
+        views.setOnClickPendingIntent(R.id.btnPrev, prevIntent)
+
+        appWidgetManager.updateAppWidget(appWidgetIds, views)
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        val prefs = HomeWidgetPlugin.getData(context)
+        var index = prefs.getInt("match_index", 0)
+        val matches = JSONArray(prefs.getString("matches", "[]"))
+        if (matches.length() == 0) return
+
+        when (intent.action) {
+            ACTION_NEXT -> index = (index + 1) % matches.length()
+            ACTION_PREV -> index = if (index - 1 < 0) matches.length() - 1 else index - 1
+        }
+        prefs.edit().putInt("match_index", index).apply()
+        HomeWidgetPlugin.updateWidget(context, MatchHomeWidgetProvider::class.java)
+    }
+}

--- a/android/app/src/main/res/layout/match_widget.xml
+++ b/android/app/src/main/res/layout/match_widget.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp"
+    android:background="@android:color/white">
+
+    <TextView
+        android:id="@+id/tvDay"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Dia"/>
+
+    <TextView
+        android:id="@+id/tvOpponent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Rival"/>
+
+    <TextView
+        android:id="@+id/tvVenue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Localia"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <ImageButton
+            android:id="@+id/btnPrev"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:src="@android:drawable/ic_media_previous" />
+
+        <ImageButton
+            android:id="@+id/btnMap"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:src="@android:drawable/ic_dialog_map" />
+
+        <ImageButton
+            android:id="@+id/btnNext"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:src="@android:drawable/ic_media_next" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/android/app/src/main/res/xml/match_widget_info.xml
+++ b/android/app/src/main/res/xml/match_widget_info.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="80dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/match_widget"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -8,6 +8,7 @@ import 'about_page.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'google_sheet_service.dart';
+import 'match_widget_updater.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -36,6 +37,7 @@ class _HomeScreenState extends State<HomeScreen> {
       setState(() {
         _data = data;
       });
+      await MatchWidgetUpdater.updateMatches(data);
     } catch (e) {
       // Manejo de errores
     }

--- a/lib/match_widget_updater.dart
+++ b/lib/match_widget_updater.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+import 'package:home_widget/home_widget.dart';
+
+class MatchWidgetUpdater {
+  static Future<void> updateMatches(List<List<dynamic>> data) async {
+    if (data.isEmpty) return;
+    final matches = <Map<String, String>>[];
+    for (var i = 1; i < data.length; i++) {
+      final row = data[i];
+      if (row.length < 4) continue;
+      matches.add({
+        'dia': row[0].toString(),
+        'fecha': row[1].toString(),
+        'localia': row[2].toString(),
+        'rival': row[3].toString(),
+        'lat': row.length > 4 ? row[4].toString() : '',
+        'long': row.length > 5 ? row[5].toString() : '',
+      });
+    }
+    await HomeWidget.saveWidgetData<String>('matches', jsonEncode(matches));
+    await HomeWidget.saveWidgetData<int>('match_index', 0);
+    await HomeWidget.updateWidget(
+      androidName: 'MatchHomeWidgetProvider',
+      qualifiedAndroidName:
+          'com.example.csdsolerapk.MatchHomeWidgetProvider',
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   url_launcher: ^6.1.0  # Para abrir enlaces externos (Google Maps)
   font_awesome_flutter: ^10.7.0
   shared_preferences: ^2.2.2
+  home_widget: ^0.5.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add `home_widget` dependency
- push upcoming matches to an Android home screen widget with arrows and map
- expose widget provider and updater

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a73375ce3c83258409a697f32170c4